### PR TITLE
Split Remit Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,27 +20,33 @@
 
   Regular expression or [picomatch] pattern that excludes files. Nothing is excluded by default.
 
-### `options` [RollupOptions] | (options: [RollupOptions]) => [RollupOptions]
+### `inputOptions` [InputOptions] | (options: [InputOptions]) => [InputOptions]
 
-  Rollup options to be used for the remit. By default, the plugin will inherit
-  all options from the main build except for `input`, `output.dir` and
-  `output.file`.  You can specify an options object to be spread into the
-  inherited options, or a transform function receiving the inherited options and
-  returning their replacement.
+  Input options to be used when spawning rollup. By default, the plugin will
+  inherit all options from the main build except for `input`.  You can specify
+  an options object to be spread into the inherited options, or a transform
+  function receiving the inherited options and returning their replacement.
 
   If a transform function is specified, it will be invoked for each module
-  matching the plugin's `include` pattern and will receive options where `input`
-  is the full path of the module being remitted. This might be used to drive
-  transform logic, but note that deleting or modifying `input` will result in an
-  error.
+  included by the plugin and will receive options where `input` is the absolute
+  module path.  This can be used to drive transform logic, but note that
+  modifying or deleting `input` will result in an error.
 
-  If you specify `output.dir` as a remit option, it will be relative to the
-  `output.dir` of the main build.
+### `outputOptions` [OutputOptions] | (options: [OutputOptions]) => [OutputOptions]
+
+  Output options to be used when spawning rollup. By default, the plugin will
+  inherit all options from the main build except for `dir` and `file`.  You can
+  specify an options object to be spread into the inherited options, or a
+  transform function receiving the inherited options and returning their
+  replacement.
+
+  If you specify `dir`, it will be relative to the `dir` of the main build output.
 
 [RegExp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 [String]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [picomatch]: https://github.com/micromatch/picomatch#globbing-features
-[RollupOptions]: https://rollupjs.org/guide/en/#big-list-of-options
+[InputOptions]: https://rollupjs.org/guide/en/#big-list-of-options
+[OutputOptions]: https://rollupjs.org/guide/en/#big-list-of-options
 
 
 ## Web Worker Example

--- a/README.md
+++ b/README.md
@@ -87,10 +87,8 @@
       plugins: [
         remit({
           include: /worker\.js$/,
-          options: {
-            output: {
-              format: 'iife'
-            }
+          outputOptions: {
+            format: 'iife'
           }
         })
       ]

--- a/examples/complex-web-worker/rollup.config.js
+++ b/examples/complex-web-worker/rollup.config.js
@@ -28,17 +28,19 @@ export default {
     }),
     remit({
       include: /worker\.js$/,
-      options({ output, plugins, ...options }) {
+      inputOptions({ plugins = [], ...options }) {
         return {
           ...options,
-          output: {
-            ...output,
-            format: 'iife'
-          },
           plugins: [
             ...plugins.filter(plugin => plugin.name == 'asset'),
             worker()
           ]
+        }
+      },
+      outputOptions(options) {
+        return {
+          ...options,
+          format: 'iife'
         }
       }
     })

--- a/examples/simple-web-worker/rollup.config.js
+++ b/examples/simple-web-worker/rollup.config.js
@@ -23,11 +23,11 @@ export default {
     }),
     remit({
       include: /worker\.js$/,
-      options: {
-        output: {
-          format: 'iife'
-        },
+      inputOptions: {
         plugins: []
+      },
+      outputOptions: {
+        format: 'iife'
       }
     })
   ]

--- a/test/input-options.test.js
+++ b/test/input-options.test.js
@@ -1,0 +1,78 @@
+import test from 'ava'
+import { rollup } from 'rollup'
+import remit from '../src/remit.js'
+
+const input = new URL('./fixtures/main.js', import.meta.url).pathname
+
+
+test('input should be the full path of the remitted file', async t => {
+  const expectedInput = new URL('./fixtures/remitted.js', import.meta.url).pathname
+  let actualInput
+
+  const options = {
+    input,
+    output: {
+      file: 'parent.js'
+    },
+    plugins: [
+      remit({
+        include: /remitted\.js$/,
+        inputOptions(options) {
+          actualInput = options.input
+        }
+      })
+    ]
+  }
+  const bundle = await rollup(options)
+  await bundle.generate(options.output)
+
+  t.is(actualInput, expectedInput)
+})
+
+test('modifying input results in an error', async t => {
+  const expectedInput = new URL('./fixtures/remitted.js', import.meta.url).pathname
+  const expectedError = {
+    code: 'PLUGIN_ERROR',
+    message: `Remit plugin options must not modify the value of "input". Expected "${expectedInput}" but was "mutated.js"`
+  }
+
+  const options = {
+    input,
+    output: {},
+    plugins: [
+      remit({
+        include: /remitted\.js$/,
+        inputOptions: {
+          input: 'mutated.js'
+        },
+      })
+    ]
+  }
+  const bundle = await rollup(options)
+
+  await t.throwsAsync(bundle.generate(options.output), expectedError)
+})
+
+
+test('plugins should not inherit remit', async t => {
+  let actualPlugins
+
+  const options = {
+    input,
+    output: {
+      file: 'parent.js'
+    },
+    plugins: [
+      remit({
+        include: /remitted\.js$/,
+        inputOptions(options) {
+          actualPlugins = options.plugins
+        }
+      })
+    ]
+  }
+  const bundle = await rollup(options)
+  await bundle.generate(options.output)
+
+  t.deepEqual(actualPlugins, [])
+})

--- a/types/remit.d.ts
+++ b/types/remit.d.ts
@@ -1,13 +1,14 @@
-import { Plugin, RollupOptions } from 'rollup'
+import { Plugin, InputOptions, OutputOptions } from 'rollup'
 
 // Redeclare FilterPattern instead of importing from @rollup/pluginutils
 // in order to avoid missing estree error:
-export type FilterPattern = ReadonlyArray<string | RegExp> | string | RegExp | null;
+export type FilterPattern = ReadonlyArray<string | RegExp> | string | RegExp | null
 
 export interface RollupRemitPluginOptions {
   include?: FilterPattern
   exclude?: FilterPattern
-  options?: RollupOptions | ((options: RollupOptions) => RollupOptions)
+  inputOptions?: InputOptions | ((options: InputOptions) => InputOptions)
+  outputOptions?: OutputOptions | ((options: OutputOptions) => OutputOptions)
 }
 
 export default function createRemitPlugin(options?: RollupRemitPluginOptions): Plugin


### PR DESCRIPTION
Splits `options` into `inputOptions` and `outputOptions`. This simplifies the plugin somewhat and makes the typescript developer experience smoother.