### PR TITLE
Deduplicate Emitted Files

### DIFF
--- a/src/remit.js
+++ b/src/remit.js
@@ -26,9 +26,8 @@ function createRemitPlugin({
     const input = pathname(id)
     const name = basename(input)
     const ref = this.emitFile({ name, type: 'asset' })
-    const fileUrl = `import.meta.ROLLUP_FILE_URL_${ref}`
-    remitted.push({ id, input, name, ref, fileUrl })
-    return `export default ${fileUrl}`
+    remitted.push({ id, input, name, ref })
+    return `export default import.meta.ROLLUP_FILE_URL_${ref}`
   }
 
   function outputOptions(options) {

--- a/test/remit.test.js
+++ b/test/remit.test.js
@@ -4,7 +4,7 @@ import remit from '../src/remit.js'
 
 const input = new URL('./fixtures/main.js', import.meta.url).pathname
 
-test('remit deduplicates emitted assets', async t => {
+test('should not emit duplicate files', async t => {
   let actualWarning
 
   const options = {
@@ -34,4 +34,50 @@ test('remit deduplicates emitted assets', async t => {
   await bundle.generate(options.output)
 
   t.is(actualWarning, undefined)
+})
+
+
+test('should warn if overwriting an existing file with different content', async t => {
+  let actualWarning
+
+  const options = {
+    input,
+    onwarn(warning) {
+      actualWarning = warning
+    },
+    output: {
+      file: 'parent.js'
+    },
+    plugins: [
+      {
+        generateBundle() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'asset.txt',
+            source: '🍄'
+          })
+        }
+      },
+      remit({
+        include: /remitted\.js$/,
+        inputOptions: {
+          plugins: [{
+            generateBundle() {
+              this.emitFile({
+                type: 'asset',
+                fileName: 'asset.txt',
+                source: '👞'
+              })
+            }
+          }]
+        }
+      })
+    ]
+  }
+  const bundle = await rollup(options)
+  await bundle.generate(options.output)
+
+  t.assert(actualWarning)
+  t.is(actualWarning.code, 'FILE_NAME_CONFLICT')
+  t.is(actualWarning.message, 'The emitted file "asset.txt" overwrites a previously emitted file of the same name.')
 })

--- a/test/remit.test.js
+++ b/test/remit.test.js
@@ -1,0 +1,37 @@
+import test from 'ava'
+import { rollup } from 'rollup'
+import remit from '../src/remit.js'
+
+const input = new URL('./fixtures/main.js', import.meta.url).pathname
+
+test('remit deduplicates emitted assets', async t => {
+  let actualWarning
+
+  const options = {
+    input,
+    onwarn(warning) {
+      actualWarning = warning
+    },
+    output: {
+      file: 'parent.js'
+    },
+    plugins: [
+      {
+        generateBundle() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'asset.txt',
+            source: '🍄'
+          })
+        }
+      },
+      remit({
+        include: /remitted\.js$/
+      })
+    ]
+  }
+  const bundle = await rollup(options)
+  await bundle.generate(options.output)
+
+  t.is(actualWarning, undefined)
+})


### PR DESCRIPTION
Prevents `FILE_NAME_CONFLICT` warnings for emitted files having the same name and content. If emitted files share the same name, but have different content, overwriting will occur and `FILE_NAME_CONFLICT` will be raised as expected.